### PR TITLE
Added Solution for RemoveCoveredIntervals Problem

### DIFF
--- a/RemoveCoveredIntervals.java
+++ b/RemoveCoveredIntervals.java
@@ -1,0 +1,35 @@
+import java.util.Comparator;
+import java.util.Stack;
+
+import static java.util.Arrays.sort;
+
+public class RemoveCoveredIntervals {
+
+    static class Comp implements Comparator<int[]> {
+        @Override
+        public int compare(int[] o1, int[] o2) {
+            return (o1[1] - o2[1]);
+        }
+    }
+
+    public static int removeCoveredIntervals(int[][] intervals) {
+        Stack<int[]> st = new Stack<>();
+        int len = intervals.length;
+
+        sort(intervals, new Comp());
+        for (int[] interval : intervals) {
+            if (st.isEmpty() || !doesCover(st.peek(), interval))
+                st.push(interval);
+            else {
+                while (!st.isEmpty() && doesCover(st.peek(), interval))
+                    st.pop();
+                st.push(interval);
+            }
+        }
+        return st.size();
+    }
+
+    public static boolean doesCover(int[] a, int[] b){
+        return (a[0] <= b[0] && a[1] >= b[1]) || (b[0] <= a[0] && b[1] >= a[1]);
+    }
+}


### PR DESCRIPTION
Added Solution for RemoveCoveredIntervals Problem

Problem Statement:
```
Given a list of intervals, remove all intervals that are covered by another interval in the list.

Interval [a,b) is covered by interval [c,d) if and only if c <= a and b <= d.

After doing so, return the number of remaining intervals.
```

Solution: 
* Sorted intervals in increasing order based on their end interval.
* If the interval is not completely covering the previous one, added the interval onto the stack.
* If the interval is covering the interval at top of the stack, popped the stack until it's no longer doing so.
* Returned the size of the stack.